### PR TITLE
Refactored to ensure Internet Explorer compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.{js,json,yaml,yml,jshintrc}]
+indent_size = 2
+indent_style = space

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,9 +1,16 @@
 {
+  "globals": {
+    "localStorage": false,
+    "define": false,
+    "module": false,
+    "require": false,
+    "exports": false,
+    "__dirname": false
+  },
   "bitwise": false,
   "camelcase": false,
   "curly": true,
   "eqeqeq": true,
-  "esnext": true,
   "forin": true,
   "immed": true,
   "indent": 2,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ session.fetch()
   .then(function () {
     console.log('Logged in as %s', session.get('name'));
   })
-  .catch(function () {
+  .fail(function () {
     console.log('Not yet logged in!');
   });
 ```
@@ -60,7 +60,7 @@ Either a Function or a String that represents the key used to access `localStora
 
 ### signIn([options])
 
-Returns: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+Returns: [jQuery Promise](https://api.jquery.com/promise/)
 
 Example:
 ```js
@@ -69,14 +69,14 @@ session.signIn({
   password: 'hunter2'
 }).then(function () {
   // Do stuff after logging in ...
-}).catch(function () {
+}).fail(function () {
   // Handle the failed log in attempt ...
 });
 ```
 
 ### signOut([options])
 
-Returns: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+Returns: [jQuery Promise](https://api.jquery.com/promise/)
 
 Example:
 ```js
@@ -87,7 +87,7 @@ session.signOut().then(function () {
 
 ### getAuthStatus([options])
 
-Returns: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+Returns: [jQuery Promise](https://api.jquery.com/promise/)
 
 Example:
 ```js
@@ -95,7 +95,7 @@ session.getAuthStatus()
 .then(function () {
   // The user is already logged in ...
 })
-.catch(function () {
+.fail(function () {
   // The user is not yet logged in ...
 });
 ```

--- a/backbone-session.js
+++ b/backbone-session.js
@@ -1,4 +1,4 @@
-(function (root, factory) {
+(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(['underscore', 'backbone'], factory);
   } else if (typeof exports === 'object') {
@@ -6,57 +6,59 @@
   } else {
     root.BackboneSession = factory(root._, root.Backbone);
   }
-}(this, function (_, Backbone) {
+}(this, function(_, Backbone) {
   return Backbone.Model.extend({
-    url: function () {
+    url: function() {
       return 'Backbone.Session';
     },
-    initialize: function (properties, options) {
+    initialize: function(properties, options) {
       this.options = options || {};
     },
-    destroy: function (options) {
+    destroy: function(options) {
       return this.sync('delete', this, options);
     },
-    sync: function (method, model, options) {
+    sync: function(method, model, options) {
       options = options || {};
       var url = model.options.url || model.url;
       var key = _.isFunction(url) ? url() : '' + url;
       var response;
       switch (method) {
-      case 'create':
-      case 'update':
-        var data = model.toJSON();
-        var text = JSON.stringify(data);
-        response = localStorage.setItem(key, text);
-        break;
-      case 'delete':
-        response = localStorage.removeItem(key);
-        break;
-      case 'read':
-        response = JSON.parse(localStorage.getItem(key));
-        break;
+        case 'create':
+        case 'update':
+          var data = model.toJSON();
+          var text = JSON.stringify(data);
+          response = localStorage.setItem(key, text);
+          break;
+        case 'delete':
+          response = localStorage.removeItem(key);
+          break;
+        case 'read':
+          response = JSON.parse(localStorage.getItem(key));
+          break;
       }
       if (_.isFunction(options.success)) {
         options.success(response);
       }
-      return Promise.resolve(response);
+      return Backbone.$.Deferred()
+        .resolve(response)
+        .promise();
     },
-    signIn: function (options) {
-      return Promise.reject(Error(
-        'Override the signIn method'
-      ));
+    signIn: function(options) {
+      return Backbone.$.Deferred()
+        .reject(Error('Override the signIn method'))
+        .promise();
     },
-    signOut: function (options) {
+    signOut: function(options) {
       options = options || {};
       this.destroy();
       this.clear();
       this.trigger('signOut');
-      return Promise.resolve();
+      return Backbone.$.Deferred().resolve().promise();
     },
-    getAuthStatus: function (options) {
-      return Promise.reject(Error(
-        'Override the getAuthStatus method'
-      ));
+    getAuthStatus: function(options) {
+      return Backbone.$.Deferred()
+        .reject(Error('Override the getAuthStatus method'))
+        .promise();
     },
     Model: Backbone.Model,
     Collection: Backbone.Collection

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,11 @@
 {
   "name": "backbone-session",
   "main": "backbone-session.js",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "homepage": "https://github.com/cofounders/backbone-session",
   "authors": [
     "Sebastiaan Deckers <seb@ninja.sg>"
+    "Émile Bergeron <ber.emile@prismalstudio.com>"
   ],
   "description": "Flexible and simple session management for Backbone apps",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,22 +1,28 @@
 {
   "name": "backbone-session",
   "description": "Flexible and simple session management for Backbone apps",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": {
     "name": "Sebastiaan Deckers",
     "email": "seb@ninja.sg"
   },
+  "contributors": [
+    {
+      "name": "Émile Bergeron",
+      "email": "ber.emile@prismalstudio.com",
+      "url": "http://www.prismalstudio.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:cofounders/backbone-session.git"
   },
-  "licenses": [{
-    "type": "MIT"
-  }],
+  "licenses": "MIT",
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
+    "backbone": "^1.3.3",
     "grunt": "0.4.1",
     "grunt-cli": "~0.1",
     "grunt-contrib-jshint": "0.10.0",
@@ -25,8 +31,7 @@
     "requirejs": "*",
     "underscore": "*"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "keywords": [
     "backbone",
     "session",

--- a/tests/amd_test.js
+++ b/tests/amd_test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var requirejs = require('requirejs');
 
 requirejs.config({

--- a/tests/commonjs_test.js
+++ b/tests/commonjs_test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 exports['CommonJS compatibility'] = {
 
   default: function (test) {


### PR DESCRIPTION
Related to issue #2. 

The lib should have the same compatibility as Backbone since it doesn't really need to depend on cutting-edge features of the language.

IE doesn't support `Promise` at all without adding another lib or a polyfill. Since Backbone already uses jQuery most of the time, it's easier to just use jQuery's [`Deferred`](https://api.jquery.com/category/deferred-object/).
